### PR TITLE
Change done indicator from ● to ✓

### DIFF
--- a/src/adapters/tui_display/mod.rs
+++ b/src/adapters/tui_display/mod.rs
@@ -57,7 +57,8 @@ impl TuiDisplay {
     ) {
         fn indicator_for(state: &str) -> &'static str {
             match state {
-                "wip" | "done" => "●",
+                "wip" => "●",
+                "done" => "✓",
                 _ => "○",
             }
         }
@@ -502,7 +503,7 @@ mod tests {
         let terminal = draw_test_show_header_box(60, &view);
 
         let output = buffer_to_string(terminal.backend().buffer());
-        assert!(output.contains("● done yak"), "got:\n{output}");
+        assert!(output.contains("✓ done yak"), "got:\n{output}");
     }
 
     #[test]

--- a/src/adapters/user_display/mod.rs
+++ b/src/adapters/user_display/mod.rs
@@ -60,13 +60,14 @@ impl ConsoleDisplay {
 /// Helper for rendering styled yak items (name + indicator) consistently
 fn style_yak_item(name: &str, state: &str, color: bool) -> String {
     let indicator = match state {
-        "wip" | "done" => "●",
+        "wip" => "●",
+        "done" => "✓",
         _ => "○",
     };
     if color {
         match state {
             "wip" => format!("\x1b[32m●\x1b[0m \x1b[1m{name}\x1b[0m"),
-            "done" => format!("\x1b[90m●\x1b[0m \x1b[90;9m{name}\x1b[0m"),
+            "done" => format!("\x1b[90m✓\x1b[0m \x1b[90;9m{name}\x1b[0m"),
             _ => format!("○ \x1b[1m{name}\x1b[0m"),
         }
     } else {
@@ -160,13 +161,14 @@ impl ConsoleDisplay {
                 ),
                 "done" => writeln!(
                     out,
-                    "{prefix}\x1b[90m●\x1b[0m \x1b[90;9m{name}\x1b[0m{dim_tags}"
+                    "{prefix}\x1b[90m✓\x1b[0m \x1b[90;9m{name}\x1b[0m{dim_tags}"
                 ),
                 _ => writeln!(out, "{prefix}○ {name}{dim_tags}"),
             }
         } else {
             let indicator = match state {
-                "wip" | "done" => "●",
+                "wip" => "●",
+                "done" => "✓",
                 _ => "○",
             };
             writeln!(out, "{prefix}{indicator} {name}{tag_suffix}")
@@ -255,7 +257,8 @@ impl crate::domain::ports::DisplayPort for ConsoleDisplay {
             let name = &view.name;
 
             let indicator = match state {
-                "wip" | "done" => "●",
+                "wip" => "●",
+                "done" => "✓",
                 _ => "○",
             };
 
@@ -295,7 +298,8 @@ impl crate::domain::ports::DisplayPort for ConsoleDisplay {
                         "├─"
                     };
                     let ci = match child.state.as_str() {
-                        "wip" | "done" => "●",
+                        "wip" => "●",
+                        "done" => "✓",
                         _ => "○",
                     };
                     format!("  {connector} {ci} {}  ", child.name)
@@ -656,7 +660,7 @@ mod tests {
             !output.contains("\x1b["),
             "unexpected ANSI codes in: {output}"
         );
-        assert!(output.contains("●"));
+        assert!(output.contains("✓"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Changes the done task indicator from a filled circle (●) to a checkmark (✓)
- WIP retains the filled circle (●), todo retains the open circle (○)
- Provides clearer visual distinction between done and WIP states

## Changes

Both display adapters updated:
- `src/adapters/user_display/mod.rs` — all indicator matches and ANSI-colored output
- `src/adapters/tui_display/mod.rs` — `indicator_for` function

## Test plan

- [x] All 557 unit tests pass (`cargo test`)
- [x] Tests for done indicator updated to assert ✓
- [x] WIP indicator tests still assert ●

🤖 Generated with [Claude Code](https://claude.com/claude-code)