### PR TITLE
feat(yx): add YX_ROOT env var to override git root detection

### DIFF
--- a/features/git_checks.feature
+++ b/features/git_checks.feature
@@ -44,6 +44,15 @@ Feature: Git repository safety checks
       Then the command should fail
       And the error should contain "not in a git repository"
 
+  Rule: YX_ROOT overrides git root detection for write operations
+
+    @fullstack
+    Example: Write operations work from a nested git repo when YX_ROOT is set
+      Given a git repository with .yaks gitignored and a yak called "workspace-yak"
+      And the workspace contains a nested git repository
+      When I mark "workspace-yak" as done from the nested git repo with YX_ROOT set
+      Then the command should succeed
+
   Rule: YX_SKIP_GIT_CHECKS bypasses all git requirements
 
     Example: YX_SKIP_GIT_CHECKS lets yx run outside a git repo

--- a/src/infrastructure/git_discovery.rs
+++ b/src/infrastructure/git_discovery.rs
@@ -9,13 +9,28 @@ use std::process::Command;
 
 /// Discover the git repository root from the current working directory.
 ///
-/// Uses `git2::Repository::discover(".")` which walks up the directory
-/// tree looking for a `.git` directory, exactly like `git rev-parse
+/// If the `YX_ROOT` environment variable is set, it is used directly as the
+/// repository root. This allows shavers who have `cd`'d into a sub-repo to
+/// anchor `.yaks` lookups to the outer workspace root (set by yak-box spawn).
+///
+/// Otherwise, uses `git2::Repository::discover(".")` which walks up the
+/// directory tree looking for a `.git` directory, exactly like `git rev-parse
 /// --show-toplevel`.
 ///
 /// Returns the working directory (workdir) of the repository.
 /// Errors if not inside a git repo or the repo is bare.
 pub fn discover_git_root() -> Result<PathBuf> {
+    if let Ok(yx_root) = std::env::var("YX_ROOT") {
+        let path = PathBuf::from(&yx_root);
+        if path.is_dir() {
+            return Ok(path);
+        }
+        anyhow::bail!(
+            "Error: YX_ROOT is set to {:?} but it is not a directory",
+            yx_root
+        );
+    }
+
     let repo = git2::Repository::discover(".")
         .map_err(|_| anyhow::anyhow!("Error: not in a git repository"))?;
 

--- a/tests/features/full_stack_world.rs
+++ b/tests/features/full_stack_world.rs
@@ -556,6 +556,70 @@ impl FullStackWorld {
         Ok(())
     }
 
+    /// Initialize the current git_repo_subdir as its own git repository,
+    /// simulating a nested/inner git repo (like repos/releng/release inside a workspace).
+    pub fn init_nested_git_repo(&mut self) -> Result<()> {
+        let repo = self.git_repo.as_ref().context("No git_repo set; call setup_git_repo_with_yak first")?;
+        let nested_path = repo.path().join("inner-repo");
+        std::fs::create_dir_all(&nested_path).context("Failed to create nested repo dir")?;
+
+        let status = Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .current_dir(&nested_path)
+            .status()
+            .context("Failed to run git init in nested repo")?;
+        if !status.success() {
+            anyhow::bail!("git init failed in nested repo");
+        }
+
+        Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&nested_path)
+            .status()
+            .context("Failed to set git user.email in nested repo")?;
+
+        Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&nested_path)
+            .status()
+            .context("Failed to set git user.name in nested repo")?;
+
+        self.git_repo_subdir = Some(nested_path);
+        Ok(())
+    }
+
+    /// Run `yx done <yak_name>` from the nested git repo directory with YX_ROOT
+    /// set to the workspace (outer) git repo root. This simulates a shaver who has
+    /// cd'd into a sub-repo and needs write ops to resolve .yaks from the workspace root.
+    pub fn run_done_from_nested_git_repo_with_yx_root(&mut self, yak_name: &str) -> Result<()> {
+        let repo = self.git_repo.as_ref().context("No git_repo set")?;
+        let workspace_root = repo.path().to_path_buf();
+        let run_dir = self
+            .git_repo_subdir
+            .clone()
+            .context("No nested git repo; call init_nested_git_repo first")?;
+        let yx_path = env!("CARGO_BIN_EXE_yx");
+
+        let output = Command::new(yx_path)
+            .args(["done", yak_name])
+            .env("YX_ROOT", &workspace_root)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env_remove("YX_SKIP_GIT_CHECKS")
+            .env_remove("YAK_PATH")
+            .current_dir(&run_dir)
+            .output()
+            .context("Failed to run yx done")?;
+
+        self.exit_code = output.status.code().unwrap_or(-1);
+        self.output = String::from_utf8_lossy(&output.stdout).to_string();
+        self.error = String::from_utf8_lossy(&output.stderr).to_string();
+
+        Ok(())
+    }
+
     /// Run bash completion by sourcing completions/yx.bash and invoking _yx_completions.
     /// The words_str is a space-separated list of words (respecting double quotes).
     /// This simulates what bash's programmable completion does.

--- a/tests/features/steps.rs
+++ b/tests/features/steps.rs
@@ -894,6 +894,19 @@ async fn list_yaks_from_subdir_with_yak_path(world: &mut FullStackWorld) -> Resu
     world.list_yaks_from_subdir_with_yak_path()
 }
 
+#[given(expr = "the workspace contains a nested git repository")]
+async fn create_nested_git_repo(world: &mut FullStackWorld) -> Result<()> {
+    world.init_nested_git_repo()
+}
+
+#[when(regex = r#"^I mark "([^"]+)" as done from the nested git repo with YX_ROOT set$"#)]
+async fn done_from_nested_git_repo_with_yx_root(
+    world: &mut FullStackWorld,
+    yak_name: String,
+) -> Result<()> {
+    world.run_done_from_nested_git_repo_with_yx_root(&yak_name)
+}
+
 #[then(expr = "the command should succeed")]
 async fn command_should_succeed(world: &mut FullStackWorld) -> Result<()> {
     check_should_succeed(world)


### PR DESCRIPTION
## Summary

Add `YX_ROOT` env var support to `discover_git_root()`. When set, it is returned directly instead of using `git2::Repository::discover()`.

This is part of a fix for yak write operations failing when a shaver cd's into a sub-repo (companion PR in [wellmaintained/yakthang#7](https://github.com/wellmaintained/yakthang/pull/7)).

## Changes

- `src/infrastructure/git_discovery.rs`: check `YX_ROOT` env var before git2 discovery
- `features/git_checks.feature`: add `@fullstack` scenario for the new behavior
- `tests/features/steps.rs`: step definitions for the new scenario
- `tests/features/full_stack_world.rs`: helper methods for nested git repo test setup

## Test plan

- [ ] `@fullstack` Cucumber test: `Write operations work from a nested git repo when YX_ROOT is set` passes with `CUCUMBER_MODE=fullstack`
- [ ] All in-process tests pass (default mode)
- [ ] `cargo clippy` clean